### PR TITLE
Another approach at installing the Command Line Tools

### DIFF
--- a/files/install_command_line_tools.sh
+++ b/files/install_command_line_tools.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+
+function ensure_command_line_tools() {
+    echo "Installing Command Line Tools"
+    local LOCKF="/tmp/.com.apple.dt.CommandLineTools.installondemand.in-progress"
+    touch "$LOCKF";
+    # shellcheck disable=SC2064
+    trap "rm $LOCKF" RETURN
+    PROD=$(softwareupdate -l |
+      grep "\*.*Command Line" |
+      head -n 1 |
+      grep -oE "Command.*" |
+      tr -d '\n')
+    softwareupdate -i "$PROD" --verbose
+}
+
+ensure_command_line_tools

--- a/lib/facter/has_compiler.rb
+++ b/lib/facter/has_compiler.rb
@@ -17,7 +17,7 @@ Facter.add(:has_compiler) do
   setcode do
     # /usr/bin/cc exists in Mavericks, but it's not real
     if Gem::Version.new(Facter.value(:macosx_productversion_major)) >= Gem::Version.new('10.9')
-      (File.exists?('/Applications/Xcode.app') or File.exists?('/Library/Developer/CommandLineTools/')) and
+      (File.exists?('/Applications/Xcode.app') or File.exists?('/Library/Developer/CommandLineTools/usr/bin')) and
           (File.exists?('/usr/bin/cc') or system('/usr/bin/xcrun -find cc >/dev/null 2>&1'))
     else
       File.exists?('/usr/bin/cc') or system('/usr/bin/xcrun -find cc >/dev/null 2>&1')

--- a/manifests/compiler.pp
+++ b/manifests/compiler.pp
@@ -1,19 +1,21 @@
 class homebrew::compiler {
 
-  if str2bool($::has_compiler) {
-  } elsif versioncmp($::macosx_productversion_major, '10.7') < 0 {
-    warning('Please install the Command Line Tools bundled with XCode manually!')
-  } elsif ($homebrew::command_line_tools_package and $homebrew::command_line_tools_source) {
-
+  if ! str2bool($::has_compiler) {
     notice('Installing Command Line Tools.')
 
-    package { $homebrew::command_line_tools_package:
-      ensure   => present,
-      provider => pkgdmg,
-      source   => $homebrew::command_line_tools_source,
+    $install_command = '/tmp/install_command_line_tools.sh'
+    file { $install_command :
+      ensure => file,
+      source => 'puppet:///modules/homebrew/install_command_line_tools.sh',
+      owner  => 'root',
+      mode   => '0744',
     }
-  } else {
-    warning('No Command Line Tools detected and no download source set. Please set download sources or install manually.')
-  }
 
+    -> exec { 'Install command line tools':
+      command => $install_command,
+      creates => '/Library/Developer/CommandLineTools/usr/bin',
+      user => 'root',
+      timeout => 60 * 10
+    }
+  }
 }


### PR DESCRIPTION
This approach is already used by our bootstrap scripts

CLT is needed for installing Python via homebrew for instance