### PR TITLE
Use custom fact to determine if node arch is arm64

### DIFF
--- a/lib/facter/has_arm64.rb
+++ b/lib/facter/has_arm64.rb
@@ -1,0 +1,20 @@
+# Fact: has_arm64
+#
+# Purpose: check if arm64 is present
+#
+# Resolution:
+#   Tests for presence of arm64, returns boolean
+#   No value set if not on Darwin
+#
+# Caveats:
+#   none
+#
+# Notes:
+#   None
+
+Facter.add(:has_arm64) do
+  confine :operatingsystem => 'Darwin'
+  setcode do
+    system('arch -arm64 true >/dev/null 2>&1')
+  end
+end

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -1,21 +1,18 @@
 class homebrew::install {
 
-  case $::facts[processors][models][0] {
+  if $::facts[has_arm64] {
     # brew complains if it finds its bin in /usr/local/bin on Apple Silicon
     # so we should put brew where it expects to be
-    /^Apple*/: {
-      $brew_root          = '/opt/homebrew'
-      $inst_dir           = $brew_root
-      $link_bin           = false
-      $brew_folders_extra = []
-    }
-    /^Intel*/: {
-      $brew_root          = '/usr/local'
-      $inst_dir           = "${brew_root}/Homebrew"
-      $link_bin           = true
-      $brew_folders_extra = ["${brew_root}/Homebrew",]
-    }
-    default:   { fail("unknown arch for processor ${::facts[processors][models][0]}") }
+    $brew_root          = '/opt/homebrew'
+    $inst_dir           = $brew_root
+    $link_bin           = false
+    $brew_folders_extra = []
+  }
+  else {
+    $brew_root          = '/usr/local'
+    $inst_dir           = "${brew_root}/Homebrew"
+    $link_bin           = true
+    $brew_folders_extra = ["${brew_root}/Homebrew",]
   }
   $brew_sys_folders = [
     "${brew_root}/bin",


### PR DESCRIPTION
The used fact to discern in homebrew required one installation or another was not available in all setups

This PR change is based off https://github.com/TheKevJames/puppet-homebrew/pull/154